### PR TITLE
feat: add target recall settings

### DIFF
--- a/src/fsrs.ts
+++ b/src/fsrs.ts
@@ -48,12 +48,17 @@ const S_after_lapse = (D: number, S: number, R: number) => {
   return W[11] * Math.pow(D, -W[12]) * (Math.pow(S + 1, W[13]) - 1) * Math.exp(W[14] * (1 - R));
 };
 
-export function fsrs45Next(prev: ReviewState, grade: 1|2|3|4, now: number): Required<ReviewState> {
+export function fsrs45Next(
+  prev: ReviewState,
+  grade: 1|2|3|4,
+  now: number,
+  targetR: number = TARGET_R
+): Required<ReviewState> {
   const isFirst = !isFinite(prev.S!) || !isFinite(prev.D!);
   if (isFirst) {
     const S = S0(grade);
     const D = clamp(D0(grade), 1, 10);
-    const I = Math.max(0.01, I_of_rS(TARGET_R, S));
+    const I = Math.max(0.01, I_of_rS(targetR, S));
     return { S, D, last: now, due: now + I * 86400000, reps: 1, lapses: grade === 1 ? 1 : 0 };
   }
 
@@ -61,7 +66,7 @@ export function fsrs45Next(prev: ReviewState, grade: 1|2|3|4, now: number): Requ
   const R = clamp(R_of_tS(t, prev.S!), 0, 1);
   const Dn = clamp(D_next(prev.D!, grade), 1, 10);
   const Sn = (grade >= 3) ? S_after_success(Dn, prev.S!, R, grade) : S_after_lapse(Dn, prev.S!, R);
-  const I = Math.max(0.01, I_of_rS(TARGET_R, Sn));
+  const I = Math.max(0.01, I_of_rS(targetR, Sn));
 
   return {
     S: Sn, D: Dn, last: now, due: now + I * 86400000,

--- a/src/index.html
+++ b/src/index.html
@@ -58,6 +58,11 @@
           class="inline-flex shrink-0 items-center justify-center rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-gray-200 transition hover:bg-slate-800 active:translate-y-px">
           ?
         </button>
+
+        <button id="settings-btn" title="Settings"
+          class="inline-flex shrink-0 items-center justify-center rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-gray-200 transition hover:bg-slate-800 active:translate-y-px">
+          Settings
+        </button>
       </div>
     </div>
 
@@ -134,6 +139,19 @@
       </details>
     </div>
   </div>
+
+  <dialog id="settings-dialog" class="rounded-lg border border-slate-700 bg-slate-900 p-4 text-gray-200">
+    <form id="settings-form" method="dialog" class="space-y-4">
+      <label class="block text-sm">
+        Target recall (%)
+        <input id="targetR-input" type="number" min="50" max="100" step="1" class="mt-1 w-full rounded-md border border-slate-700 bg-slate-800 p-2" />
+      </label>
+      <div class="mt-3 flex justify-end gap-2">
+        <button type="button" id="settings-cancel" class="rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 text-sm text-gray-200 transition hover:bg-slate-800 active:translate-y-px">Cancel</button>
+        <button type="submit" class="rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 text-sm text-gray-200 transition hover:bg-slate-800 active:translate-y-px">Save</button>
+      </div>
+    </form>
+  </dialog>
 
   <!-- Parcel will bundle this and our postbuild step will inline it so the final file is one HTML -->
   <script type="module">import "./main.ts"</script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,11 @@ const newPill = $('#new-pill') as HTMLElement;
 const metaId = $('#meta-id') as HTMLElement;
 const metaNext = $('#meta-next') as HTMLElement;
 const metaStats = $('#meta-stats') as HTMLElement;
+const settingsBtn = $('#settings-btn') as HTMLButtonElement;
+const settingsDialog = $('#settings-dialog') as HTMLDialogElement;
+const targetRInput = $('#targetR-input') as HTMLInputElement;
+const settingsForm = $('#settings-form') as HTMLFormElement;
+const settingsCancel = $('#settings-cancel') as HTMLButtonElement;
 
 let STATE: AppState = loadState();
 let CARDS: Card[] = cards;
@@ -97,7 +102,7 @@ function rate(grade: 1|2|3|4) {
     due: +prev.due  || nowMs(),
     reps: +prev.reps || 0,
     lapses: +prev.lapses || 0
-  }, grade, nowMs());
+  }, grade, nowMs(), STATE.targetR);
 
   STATE.cards[id] = next;
   saveState(STATE);
@@ -151,6 +156,23 @@ $('#reset-btn')!.addEventListener('click', () => {
 
 $('#help-btn')!.addEventListener('click', () => {
   const d = document.getElementById('help') as HTMLDetailsElement; if (d) d.open = !d.open;
+});
+
+settingsBtn.addEventListener('click', () => {
+  targetRInput.value = Math.round((STATE.targetR || 0.9) * 100).toString();
+  settingsDialog.showModal();
+});
+
+settingsCancel.addEventListener('click', () => settingsDialog.close());
+
+settingsForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const val = parseFloat(targetRInput.value);
+  if (!isNaN(val)) {
+    STATE.targetR = Math.max(0.5, Math.min(0.99, val / 100));
+    saveState(STATE);
+  }
+  settingsDialog.close();
 });
 
 // Initial render


### PR DESCRIPTION
## Summary
- allow FSRS scheduler to accept a custom target recall probability
- add settings dialog to configure target recall percentage
- persist chosen recall target and use it when scheduling reviews

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6e7995a08333801b372949d2234a