### PR TITLE
Add card list view with due dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "source": [
-    "src/index.html"
+    "src/index.html",
+    "src/list.html"
   ],
   "type": "module",
   "scripts": {

--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,10 @@
       <!-- Actions: horizontally scrollable on mobile -->
       <div class="order-last -mx-3 flex gap-2 overflow-x-auto px-3 pb-1 pt-1 sm:order-none sm:ml-auto sm:overflow-visible sm:p-0
                   [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+        <a href="list.html" title="View all cards and due dates"
+          class="inline-flex shrink-0 items-center rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-gray-200 transition hover:bg-slate-800 active:translate-y-px md:px-4">
+          Cards
+        </a>
         <button id="export-btn" title="Download your study state as JSON"
           class="inline-flex shrink-0 items-center rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-gray-200 transition hover:bg-slate-800 active:translate-y-px md:px-4">
           Export

--- a/src/list.html
+++ b/src/list.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>All Cards - FSRS Flashcards</title>
+  <style>
+    @import "./styles.css";
+  </style>
+</head>
+<body class="min-h-dvh bg-[radial-gradient(1200px_800px_at_20%_10%,#0f172a_0%,#0b0f14_60%)] text-gray-200 antialiased">
+  <div class="mx-auto w-full max-w-screen-sm px-3 py-4 md:max-w-[920px] md:px-6 md:py-6">
+    <div class="mb-4 flex items-center justify-between">
+      <div class="text-base font-bold tracking-[0.2px] sm:text-lg">All Cards</div>
+      <a href="index.html" class="inline-flex shrink-0 items-center rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-gray-200 transition hover:bg-slate-800 active:translate-y-px md:px-4">Back</a>
+    </div>
+    <table class="w-full text-left text-sm text-gray-300" id="cards-table">
+      <thead>
+        <tr class="border-b border-slate-700 text-gray-400">
+          <th class="py-2 pr-4">ID</th>
+          <th class="py-2 pr-4">Front</th>
+          <th class="py-2">Due</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <script type="module">import "./list.ts"</script>
+</body>
+</html>

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,0 +1,19 @@
+import cards from "./cards.json";
+import { loadState } from "./state";
+
+const tbody = document.querySelector('#cards-table tbody') as HTMLElement;
+const state = loadState();
+
+const rows = cards.map(card => {
+  const st = state.cards[card.id] || {};
+  const dueMs = Number(st.due);
+  const due = isFinite(dueMs) ? new Date(dueMs).toLocaleString() : 'new';
+  return { ...card, dueMs: isFinite(dueMs) ? dueMs : Infinity, due };
+}).sort((a, b) => a.dueMs - b.dueMs);
+
+for (const row of rows) {
+  const tr = document.createElement('tr');
+  tr.className = 'border-b border-slate-700 last:border-0';
+  tr.innerHTML = `<td class="py-2 pr-4">${row.id}</td><td class="py-2 pr-4">${row.front}</td><td class="py-2">${row.due}</td>`;
+  tbody.appendChild(tr);
+}


### PR DESCRIPTION
## Summary
- add link to a new cards list view
- include list view which displays card IDs, fronts, and due dates
- update build source entries to include list view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6e8cdcb88333a466511aa08a5a87