### PR TITLE
feat: add study ahead option

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -76,6 +76,13 @@
         </button>
       </div>
 
+      <div id="ahead-row" class="mt-4 hidden flex flex-wrap gap-3">
+        <button id="ahead-btn"
+          class="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-slate-700 bg-slate-900 px-4 py-3 text-sm font-medium text-gray-200 transition hover:bg-slate-800 active:translate-y-px sm:w-auto">
+          Study ahead
+        </button>
+      </div>
+
       <div id="rate-row" class="mt-3 hidden grid grid-cols-2 gap-2 sm:grid-cols-4">
         <button
           class="rounded-lg border border-red-400/40 bg-red-900/40 px-3 py-3 text-center text-sm font-semibold text-red-100 transition hover:bg-red-900/50 active:translate-y-px"


### PR DESCRIPTION
## Summary
- show a notice when no cards are due and offer a study-ahead button
- allow reviewing future or unseen cards after choosing to study ahead

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6eb826ec8333bad7f9d8a0ab2d82